### PR TITLE
Update for use with current DeZog.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,13 +15,9 @@
 			},
 			"topOfStack": "Stack_Top",
 			"rootFolder": "${fileDirname}",
-			"listFiles": [
+			"sjasmplus": [
 				{
-					"path": "${fileDirname}/${fileBasenameNoExtension}.lst",
-					"asm": "sjasmplus",
-					"useFiles": true,
-					"mainFile": "${fileDirname}/${fileBasenameNoExtension}.z80",
-					"srcDirs": [ "lib" ]
+					"path": "${fileDirname}/${fileBasenameNoExtension}.sld",
 				}
 			],
 			"disassemblerArgs": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,10 +6,11 @@
  		{
             "label": "sjasmplus",
             "type": "shell",
-            "command": "sjasmplus",    						
+            "command": "sjasmplus",
             "args": [
-				"--lst=${fileDirname}/${fileBasenameNoExtension}.lst",
-            	"${file}"                                   
+				"--sld=${fileDirname}/${fileBasenameNoExtension}.sld",
+                "--fullpath",
+            	"${file}"
 			],
             "group": {
                 "kind": "build",

--- a/demo/demo_colourbars.z80
+++ b/demo/demo_colourbars.z80
@@ -141,5 +141,5 @@ Colour_Table:		DUP 8
 
 Code_Length:		EQU $-Code_Start+1
 
-			SAVESNA "Z80/Demo/demo_colourbars.sna", Code_Start
+			SAVESNA "demo/demo_colourbars.sna", Code_Start
 


### PR DESCRIPTION
The latest version of DeZog no longer supports .lst files from sjasmplus, and has also slightly changed how options should be supplied to it. This changes `launch.json` to keep it up to date.

I also fixed an erroneous path in `demo_colourbars.z80` that was stopping it from compiling and running (maybe this wasn't a problem before, when the paths were passed ini the config file rather than in get .sld?)